### PR TITLE
Fix multi-line string in assignments

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,5 +1,6 @@
 .vscode/**
 .vscode-test/**
+./samples/**
 .gitignore
 vsc-extension-quickstart.md
 get_ico.ps1

--- a/samples/multi_line.talon
+++ b/samples/multi_line.talon
@@ -1,3 +1,5 @@
+
+# Example from the talon wiki https://talon.wiki/Customization/talon-files
 # Comments must be on their own line (optionally preceeded by whitespace)
 some [<user.letter>] command:
     # or operator is used to deal with optional or alternative command parts. It works as the null

--- a/samples/multi_line.talon
+++ b/samples/multi_line.talon
@@ -1,0 +1,51 @@
+# Comments must be on their own line (optionally preceeded by whitespace)
+some [<user.letter>] command:
+    # or operator is used to deal with optional or alternative command parts. It works as the null
+    # coalescing operator, not like boolean or.
+    letter_defaulted = letter or "default"
+
+    """
+    type in this
+    multiline
+    string using auto_insert()
+    """
+
+    # Local variable assignment
+    a = 2.2
+    b = "foo"
+    c = "interpolate the {letter_defaulted} and {b} variables into the string"
+    c =     """
+    multiline string
+    """
+    # Only a single mathematical operation per line
+    d = 2
+    a = a + d
+    a = a - d
+    a = a * d
+    a = a / d
+    a = a % d
+
+    # Sleep is a built in function and takes arguments of the (<float>|<integer><suffix>) form.
+    # Float allows specifying (fractions) of a second. The <integer><suffix> form can be '1m', '5s', '500ms', '1000000us' etc.
+    # Be aware sleeping in this way will prevent Talon from processing voice commands until the
+    # sleep is over
+    sleep(2s)
+
+    # Repeats the previous line the given number of times, so in this case we'd sleep for a further 4 seconds
+    repeat(2)
+
+    # The key() action. Allows pressing, holding, and repeating individual key presses.
+    # See the "key() action" wiki page for more details
+    key(ctrl-f)
+
+    insert("type in this literal string")
+    auto_insert("process this string with the auto_format action, then type it in with insert()")
+
+    # Stylistically we only recommend the following shorthand if it is the only action being
+    # performed by the command.
+    "type in this string using auto_insert()"
+
+
+    # Call built in or user defined actions
+    app.notify("show this in a notification balloon")
+    user.grid_activate()

--- a/syntaxes/talon.tmLanguage.json
+++ b/syntaxes/talon.tmLanguage.json
@@ -233,7 +233,7 @@
     "qstring-long": {
       "begin": "(\"\"\"|''')",
       "end": "(\\1)",
-      "name": "string.quoted.double.talon",
+      "name": "string.quoted.triple.talon",
       "beginCaptures": {
         "1": {
           "name": "punctuation.definition.string.begin.talon"
@@ -452,26 +452,24 @@
       }
     },
     "assignment": {
-      "match": "(\\S*)(\\s?=\\s?)(.*)",
-      "captures": {
+      "begin": "(\\S*)(\\s?=\\s?)",
+      "end": "\n",
+      "beginCaptures": {
         "1": {
           "name": "variable.other.talon"
         },
         "2": {
           "name": "keyword.operator.talon"
-        },
-        "3": {
-          "name": "variable.other.talon",
-          "patterns": [
-            {
-              "include": "#comment"
-            },
-            {
-              "include": "#expression"
-            }
-          ]
         }
-      }
+      },
+      "patterns": [
+        {
+          "include": "#comment"
+        },
+        {
+          "include": "#expression"
+        }
+      ]
     },
     "expression": {
       "patterns": [

--- a/syntaxes/talon.tmLanguage.yml
+++ b/syntaxes/talon.tmLanguage.yml
@@ -129,7 +129,7 @@ repository:
   qstring-long:
     begin: ("""|''')
     end: (\1)
-    name: string.quoted.double.talon
+    name: string.quoted.triple.talon
     beginCaptures:
       "1":
         name: punctuation.definition.string.begin.talon
@@ -252,17 +252,16 @@ repository:
       "3":
         name: punctuation.definition.parameters.end.talon
   assignment:
-    match: (\S*)(\s?=\s?)(.*)
-    captures:
+    begin: (\S*)(\s?=\s?)
+    end: "\n"
+    beginCaptures:
       "1":
         name: variable.other.talon
       "2":
         name: keyword.operator.talon
-      "3":
-        name: variable.other.talon
-        patterns:
-          - include: "#comment"
-          - include: "#expression"
+    patterns:
+      - include: "#comment"
+      - include: "#expression"
   expression:
     patterns:
       - include: "#qstring-long"


### PR DESCRIPTION
The pull request fixed the issues shown in #8. The core issue was that matches can not be multi-line even if the contain  captures that would be a multi line capture. To get around this we have to use the `begin` `end` version to make it allow there to be new lines. Then move the last capture to the patterns field to be matched into the inner of the rule.